### PR TITLE
Update anchor_tabular_adult.ipynb

### DIFF
--- a/examples/anchor_tabular_adult.ipynb
+++ b/examples/anchor_tabular_adult.ipynb
@@ -23,7 +23,7 @@
     "from sklearn.metrics import accuracy_score\n",
     "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n",
     "from alibi.explainers import AnchorTabular\n",
-    "from alibi.datasets import fetch_adult"
+    "from alibi.datasets import fetch_adult as adult"
    ]
   },
   {


### PR DESCRIPTION
```
>>> import alibi
alibi.__>>> alibi.__version__
'0.5.7'
>>> from alibi.datasets import adult
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'adult' from 'alibi.datasets' (/Users/enricorotundo/anaconda3/envs/pachy/lib/python3.8/site-packages/alibi/datasets.py)
```

Fix:
`from alibi.datasets import fetch_adult as adult`